### PR TITLE
Update parse_EC_number_after_funannotate.py

### DIFF
--- a/parse_EC_number_after_funannotate.py
+++ b/parse_EC_number_after_funannotate.py
@@ -24,7 +24,7 @@ def scrape_ec(ec):
     soup = BeautifulSoup(html_content, "lxml")
     ecnumber = soup.title.prettify()
     #parse only the name out of the title
-    enzyme_name = (ecnumber[(ecnumber.find(ec))+len(ec)+1:-10])
+    enzyme_name = (ecnumber[(ecnumber.find(ec))+len(ec)+1:-10]).replace(",","%2C")# same change for existing names in GFF
     return enzyme_name
 
 


### PR DESCRIPTION
Encode comma (,) characters in product names with `%2C`. table2asn trims and discards everything after the comma